### PR TITLE
Update GitHub Actions workflow to support multi-architecture docker image builds

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -7,6 +7,7 @@ name: Build Docker image & push
 on:
   release:
     types: [published]
+  pull_request:
 
 jobs:
   build-docker-image:
@@ -17,24 +18,31 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_HOSTNAME }}/${{ env.IMAGE_NODE }}
 
-      - name: Build image
-        run: |
-          TAG_VERSION=${{ steps.get_version.outputs.VERSION }}
-          cd ${GITHUB_WORKSPACE} && docker build -t "${REGISTRY_HOSTNAME}/${IMAGE_NODE}:${TAG_VERSION}" -f ./docker/Dockerfile .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Log into Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Push image
-        run: |
-          TAG_VERSION=${{ steps.get_version.outputs.VERSION }}
-          docker push "${REGISTRY_HOSTNAME}/${IMAGE_NODE}:${TAG_VERSION}"
+      - name: Build and push image to Docker Hub
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.20.7 as builder
+LABEL maintainer="multiversx"
 
 RUN apt-get update && apt-get install -y
 
@@ -12,8 +13,14 @@ WORKDIR /go/mx-chain-go
 #MultiversX node
 WORKDIR /go/mx-chain-go/cmd/node
 RUN go build -v -ldflags="-X main.appVersion=$(git describe --git-dir /config/.git --tags --long --dirty)"
-RUN cp /go/pkg/mod/github.com/multiversx/$(cat /go/mx-chain-go/go.mod | grep mx-chain-vm-v | sort -n | tail -n -1| awk -F '/' '{print$3}'| sed 's/ /@/g')/wasmer/libwasmer_linux_amd64.so /lib/libwasmer_linux_amd64.so
-RUN cp /go/pkg/mod/github.com/multiversx/$(cat /go/mx-chain-go/go.mod | grep mx-chain-vm-go | sort -n | tail -n -1| awk -F '/' '{print$3}'| sed 's/ /@/g')/wasmer2/libvmexeccapi.so /lib/libvmexeccapi.so
+
+RUN mkdir -p /lib_amd64 /lib_arm64
+
+RUN cp /go/pkg/mod/github.com/multiversx/$(cat /go/mx-chain-go/go.mod | grep mx-chain-vm-v | sort -n | tail -n -1| awk -F '/' '{print$3}'| sed 's/ /@/g')/wasmer/libwasmer_linux_amd64.so /lib_amd64/
+RUN cp /go/pkg/mod/github.com/multiversx/$(cat /go/mx-chain-go/go.mod | grep mx-chain-vm-go | sort -n | tail -n -1| awk -F '/' '{print$3}'| sed 's/ /@/g')/wasmer2/libvmexeccapi.so /lib_amd64/
+
+RUN cp /go/pkg/mod/github.com/multiversx/$(cat /go/mx-chain-go/go.mod | grep mx-chain-vm-v | sort -n | tail -n -1 | awk -F '/' '{print$3}' | sed 's/ /@/g')/wasmer/libwasmer_linux_arm64_shim.so /lib_arm64/
+RUN cp /go/pkg/mod/github.com/multiversx/$(cat /go/mx-chain-go/go.mod | grep mx-chain-vm-go | sort -n | tail -n -1 | awk -F '/' '{print$3}' | sed 's/ /@/g')/wasmer2/libvmexeccapi_arm.so /lib_arm64/
 
 WORKDIR /config
 RUN cp -r * /go/mx-chain-go/cmd/node/config/
@@ -22,10 +29,13 @@ WORKDIR /go/mx-chain-go/cmd/node
 
 # ===== SECOND STAGE ======
 FROM ubuntu:22.04
+ARG TARGETARCH
 RUN apt-get update -y && apt-get upgrade -y
+
 COPY --from=builder "/go/mx-chain-go/cmd/node" "/go/mx-chain-go/cmd/node/"
-COPY --from=builder "/lib/libwasmer_linux_amd64.so" "/lib/libwasmer_linux_amd64.so"
-COPY --from=builder "/lib/libvmexeccapi.so" "/lib/libvmexeccapi.so"
+
+# Copy architecture-specific files
+COPY --from=builder "/lib_${TARGETARCH}/*" "/lib/"
 
 WORKDIR /go/mx-chain-go/cmd/node/
 EXPOSE 8080


### PR DESCRIPTION
Dockerfile:
- Updated the Dockerfile for conditional copying of required files for amd64/arm64

GitHub Actions workflow:
- Added docker/metadata-action@v5 to automatically generate image tags and labels
- Replaced manual Docker build and push steps with docker/build-push-action@v5